### PR TITLE
Integrate FiftyOne for loading datasets and visualizing video classification predictions

### DIFF
--- a/flash/core/classification.py
+++ b/flash/core/classification.py
@@ -242,7 +242,7 @@ class FiftyOneLabels(ClassificationSerializer):
         else:
             rank_zero_warn("No LabelsState was found, this serializer will act as a Classes serializer.", UserWarning)
             fo_labels = Classification(
-                label = classes,
+                label = str(classes),
                 confidence = max(probabilities),
                 logits = logits
             )

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -1054,6 +1054,7 @@ class DataModule(pl.LightningDataModule):
         :class:`~flash.core.data.data_source.DataSource` of name
         :attr:`~flash.core.data.data_source.DefaultDataSources.FIFTYONE`
         from the passed or constructed :class:`~flash.core.data.process.Preprocess`.
+
         Args:
             train_dataset: The FiftyOne Dataset containing the train data.
             val_dataset: The FiftyOne Dataset containing the validation data.
@@ -1077,11 +1078,18 @@ class DataModule(pl.LightningDataModule):
             num_workers: The ``num_workers`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
             preprocess_kwargs: Additional keyword arguments to use when constructing the preprocess. Will only be used
                 if ``preprocess = None``.
+
         Returns:
             The constructed data module.
+
         Examples::
-            data_module = DataModule.from_folders(
-                train_folder="train_folder",
+
+            train_dataset = fo.Dataset.from_dir(
+                "/path/to/dataset",
+                dataset_type=fo.types.ImageClassificationDirectoryTree,
+            )
+            data_module = DataModule.from_fiftyone(
+                train_data = train_dataset,
                 train_transform={
                     "to_tensor_transform": torch.as_tensor,
                 },

--- a/flash/core/data/data_module.py
+++ b/flash/core/data/data_module.py
@@ -30,6 +30,12 @@ from flash.core.data.data_pipeline import DataPipeline, DefaultPreprocess, Postp
 from flash.core.data.data_source import DatasetDataSource, DataSource, DefaultDataSources
 from flash.core.data.splits import SplitDataset
 from flash.core.data.utils import _STAGES_PREFIX
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.collections import SampleCollection
+else:
+    SampleCollection = None
 
 
 class DataModule(pl.LightningDataModule):
@@ -1009,6 +1015,80 @@ class DataModule(pl.LightningDataModule):
         """
         return cls.from_data_source(
             DefaultDataSources.DATASET,
+            train_dataset,
+            val_dataset,
+            test_dataset,
+            predict_dataset,
+            train_transform=train_transform,
+            val_transform=val_transform,
+            test_transform=test_transform,
+            predict_transform=predict_transform,
+            data_fetcher=data_fetcher,
+            preprocess=preprocess,
+            val_split=val_split,
+            batch_size=batch_size,
+            num_workers=num_workers,
+            **preprocess_kwargs,
+        )
+
+    @classmethod
+    def from_fiftyone(
+        cls,
+        train_dataset: Optional[SampleCollection] = None,
+        val_dataset: Optional[SampleCollection] = None,
+        test_dataset: Optional[SampleCollection] = None,
+        predict_dataset: Optional[SampleCollection] = None,
+        train_transform: Optional[Dict[str, Callable]] = None,
+        val_transform: Optional[Dict[str, Callable]] = None,
+        test_transform: Optional[Dict[str, Callable]] = None,
+        predict_transform: Optional[Dict[str, Callable]] = None,
+        data_fetcher: Optional[BaseDataFetcher] = None,
+        preprocess: Optional[Preprocess] = None,
+        val_split: Optional[float] = None,
+        batch_size: int = 4,
+        num_workers: Optional[int] = None,
+        **preprocess_kwargs: Any,
+    ) -> 'DataModule':
+        """Creates a :class:`~flash.core.data.data_module.DataModule` object
+        from the given FiftyOne Datasets using the
+        :class:`~flash.core.data.data_source.DataSource` of name
+        :attr:`~flash.core.data.data_source.DefaultDataSources.FIFTYONE`
+        from the passed or constructed :class:`~flash.core.data.process.Preprocess`.
+        Args:
+            train_dataset: The FiftyOne Dataset containing the train data.
+            val_dataset: The FiftyOne Dataset containing the validation data.
+            test_dataset: The FiftyOne Dataset containing the test data.
+            predict_dataset: The FiftyOne Dataset containing the predict data.
+            train_transform: The dictionary of transforms to use during training which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            val_transform: The dictionary of transforms to use during validation which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            test_transform: The dictionary of transforms to use during testing which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            predict_transform: The dictionary of transforms to use during predicting which maps
+                :class:`~flash.core.data.process.Preprocess` hook names to callable transforms.
+            data_fetcher: The :class:`~flash.core.data.callback.BaseDataFetcher` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`.
+            preprocess: The :class:`~flash.core.data.data.Preprocess` to pass to the
+                :class:`~flash.core.data.data_module.DataModule`. If ``None``, ``cls.preprocess_cls``
+                will be constructed and used.
+            val_split: The ``val_split`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            batch_size: The ``batch_size`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            num_workers: The ``num_workers`` argument to pass to the :class:`~flash.core.data.data_module.DataModule`.
+            preprocess_kwargs: Additional keyword arguments to use when constructing the preprocess. Will only be used
+                if ``preprocess = None``.
+        Returns:
+            The constructed data module.
+        Examples::
+            data_module = DataModule.from_folders(
+                train_folder="train_folder",
+                train_transform={
+                    "to_tensor_transform": torch.as_tensor,
+                },
+            )
+        """
+        return cls.from_data_source(
+            DefaultDataSources.FIFTYONE,
             train_dataset,
             val_dataset,
             test_dataset,

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -42,6 +42,11 @@ from flash.core.data.auto_dataset import AutoDataset, BaseAutoDataset, IterableA
 from flash.core.data.properties import ProcessState, Properties
 from flash.core.data.utils import CurrentRunningStageFuncContext
 
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.collections import SampleCollection
+else:
+    SampleCollection = None
+
 
 # Credit to the PyTorchVision Team:
 # https://github.com/pytorch/vision/blob/master/torchvision/datasets/folder.py#L10
@@ -461,3 +466,13 @@ class TensorDataSource(SequenceDataSource[torch.Tensor]):
 class NumpyDataSource(SequenceDataSource[np.ndarray]):
     """The ``NumpyDataSource`` is a ``SequenceDataSource`` which expects the input to
     :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence of ``np.ndarray`` objects."""
+
+class FiftyOneDataSource(SequenceDataSource[SampleCollection]):
+    """The ``FiftyOneDataSource`` is a ``SequenceDataSource`` which expects the input to
+    :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence
+    of FiftyOne Dataset objects."""
+
+    def predict_load_data(self,
+                          data: SampleCollection,
+                          dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
+        return [{DefaultDataKeys.INPUT: s.filepath} for s in data] 

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -41,6 +41,7 @@ from torch.utils.data.dataset import Dataset
 from flash.core.data.auto_dataset import AutoDataset, BaseAutoDataset, IterableAutoDataset
 from flash.core.data.properties import ProcessState, Properties
 from flash.core.data.utils import CurrentRunningStageFuncContext
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
 
 if _FIFTYONE_AVAILABLE:
     from fiftyone.core.collections import SampleCollection
@@ -150,6 +151,7 @@ class DefaultDataSources(LightningEnum):
     CSV = "csv"
     JSON = "json"
     DATASET = "dataset"
+    FIFTYONE = "fiftyone"
 
     # TODO: Create a FlashEnum class???
     def __hash__(self) -> int:

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -487,9 +487,8 @@ class FiftyOneDataSource(DataSource[SampleCollection]):
         parses sample filenames and labels from the given label field into a
         list of inputs and targets.
         """
-        filepaths = data.values("filepath")
         _, label_path = data._get_label_field_path(self.label_field, "label")
-        targets = data.values(label_path)
+        filepaths, targets = data.values(["filepath", label_path])
 
         classes = data.default_classes
         if not classes:

--- a/flash/core/data/data_source.py
+++ b/flash/core/data/data_source.py
@@ -469,12 +469,11 @@ class NumpyDataSource(SequenceDataSource[np.ndarray]):
     """The ``NumpyDataSource`` is a ``SequenceDataSource`` which expects the input to
     :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence of ``np.ndarray`` objects."""
 
-class FiftyOneDataSource(SequenceDataSource[SampleCollection]):
-    """The ``FiftyOneDataSource`` is a ``SequenceDataSource`` which expects the input to
-    :meth:`~flash.core.data.data_source.DataSource.load_data` to be a sequence
-    of FiftyOne Dataset objects."""
+class FiftyOneDataSource(DataSource[SampleCollection]):
+    """The ``FiftyOneDataSource`` expects the input to
+    :meth:`~flash.core.data.data_source.DataSource.load_data` to be FiftyOne Dataset objects."""
 
     def predict_load_data(self,
                           data: SampleCollection,
                           dataset: Optional[Any] = None) -> Sequence[Mapping[str, Any]]:
-        return [{DefaultDataKeys.INPUT: s.filepath} for s in data] 
+        return [{DefaultDataKeys.INPUT: f} for f in data.values("filepath")] 

--- a/flash/core/utilities/imports.py
+++ b/flash/core/utilities/imports.py
@@ -75,6 +75,7 @@ _PYTORCHVIDEO_AVAILABLE = _module_available("pytorchvideo")
 _MATPLOTLIB_AVAILABLE = _module_available("matplotlib")
 _TRANSFORMERS_AVAILABLE = _module_available("transformers")
 _PYSTICHE_AVAILABLE = _module_available("pystiche")
+_FIFTYONE_AVAILABLE = _module_available("fiftyone")
 
 if Version:
     _TORCHVISION_GREATER_EQUAL_0_9 = _compare_version("torchvision", operator.ge, "0.9.0")

--- a/flash/image/classification/data.py
+++ b/flash/image/classification/data.py
@@ -25,7 +25,7 @@ from flash.core.data.data_source import DefaultDataKeys, DefaultDataSources
 from flash.core.data.process import Preprocess
 from flash.core.utilities.imports import _IMAGE_AVAILABLE, _MATPLOTLIB_AVAILABLE
 from flash.image.classification.transforms import default_transforms, train_default_transforms
-from flash.image.data import ImageNumpyDataSource, ImagePathsDataSource, ImageTensorDataSource
+from flash.image.data import ImageFiftyOneDataSource, ImageNumpyDataSource, ImagePathsDataSource, ImageTensorDataSource
 
 if _MATPLOTLIB_AVAILABLE:
     import matplotlib.pyplot as plt
@@ -49,7 +49,12 @@ class ImageClassificationPreprocess(Preprocess):
         test_transform: Optional[Dict[str, Callable]] = None,
         predict_transform: Optional[Dict[str, Callable]] = None,
         image_size: Tuple[int, int] = (196, 196),
+        **data_source_kwargs,
     ):
+        """
+        ``data_source_kwargs`` are source-specific keyword arguments that are
+        passed to the ``DataSource`` constructors
+        """
         self.image_size = image_size
 
         super().__init__(
@@ -58,6 +63,7 @@ class ImageClassificationPreprocess(Preprocess):
             test_transform=test_transform,
             predict_transform=predict_transform,
             data_sources={
+                DefaultDataSources.FIFTYONE: ImageFiftyOneDataSource(**data_source_kwargs),
                 DefaultDataSources.FILES: ImagePathsDataSource(),
                 DefaultDataSources.FOLDERS: ImagePathsDataSource(),
                 DefaultDataSources.NUMPY: ImageNumpyDataSource(),

--- a/flash/image/data.py
+++ b/flash/image/data.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, Optional
 
 import torch
 
-from flash.core.data.data_source import DefaultDataKeys, NumpyDataSource, PathsDataSource, TensorDataSource
+from flash.core.data.data_source import DefaultDataKeys, FiftyOneDataSource, NumpyDataSource, PathsDataSource, TensorDataSource
 from flash.core.utilities.imports import _TORCHVISION_AVAILABLE
 
 if _TORCHVISION_AVAILABLE:
@@ -46,4 +46,10 @@ class ImageNumpyDataSource(NumpyDataSource):
 
     def load_sample(self, sample: Dict[str, Any], dataset: Optional[Any] = None) -> Dict[str, Any]:
         sample[DefaultDataKeys.INPUT] = to_pil_image(torch.from_numpy(sample[DefaultDataKeys.INPUT]))
+        return sample
+
+class ImageFiftyOneDataSource(FiftyOneDataSource):
+
+    def load_sample(self, sample: Dict[str, Any], dataset: Optional[Any] = None) -> Dict[str, Any]:
+        sample[DefaultDataKeys.INPUT] = default_loader(sample[DefaultDataKeys.INPUT])
         return sample

--- a/flash/image/detection/data.py
+++ b/flash/image/detection/data.py
@@ -127,12 +127,11 @@ class ObjectDetectionFiftyOneDataSource(ImageFiftyOneDataSource):
         list of inputs and targets.
         """
         data.compute_metadata()
-        filepaths = data.values("filepath")
+
+        filepaths, widths, heights = data.values(["filepath", "metadata.width", "metadata.height"])
         labels = data.values(self.label_field + ".detections.label")
         bboxes = data.values(self.label_field + ".detections.bounding_box")
         iscrowds = data.values(self.label_field + ".detections." + self.iscrowd)
-        widths = data.values("metadata.width")
-        heights = data.values("metadata.height")
 
         classes = data.default_classes
         if not classes:

--- a/flash/image/detection/serialization.py
+++ b/flash/image/detection/serialization.py
@@ -1,0 +1,73 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any, Dict, List, Optional
+
+from pytorch_lightning.utilities import rank_zero_warn
+
+from flash.core.data.data_source import LabelsState
+from flash.core.data.process import Serializer
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE
+
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.labels import Detection, Detections
+
+class FiftyOneDetectionLabels(Serializer):
+    """A :class:`.Serializer` which converts the model outputs to a FiftyOne Detections label.
+    """
+
+    def __init__(
+            self,
+            labels: Optional[List[str]] = None,
+        ):
+        if not _FIFTYONE_AVAILABLE:
+            raise ModuleNotFoundError("Please, run `pip install fiftyone`.")
+        super().__init__()
+        self._labels = labels
+
+        if labels is not None:
+            self.set_state(LabelsState(labels))
+
+    def serialize(self, sample: List[Dict[str, Any]]) -> Detections:
+        labels = None
+
+        if self._labels is not None:
+            labels = self._labels
+        else:
+            state = self.get_state(LabelsState)
+            if state is not None:
+                labels = state.labels
+            else:
+                rank_zero_warn("No LabelsState was found, this serializer will return integer class labels.", UserWarning)
+
+        detections = []
+
+        for det in sample:
+            xmin, ymin, xmax, ymax = [c.tolist() for c in det["boxes"]]
+            box = [xmin, ymin, xmax-xmin, ymax-ymin]
+
+            label = det["labels"].tolist()
+            if labels is not None:
+                label = labels[label]
+            else:
+                label = str(int(label))
+
+            score = det["scores"].tolist()
+            detections.append(Detection(
+                label = label,
+                bounding_box = box,
+                confidence = score,
+            ))
+
+
+        return Detections(detections=detections)

--- a/flash/image/segmentation/serialization.py
+++ b/flash/image/segmentation/serialization.py
@@ -19,7 +19,10 @@ import torch
 import flash
 from flash.core.data.data_source import DefaultDataKeys, ImageLabelsMap
 from flash.core.data.process import Serializer
-from flash.core.utilities.imports import _KORNIA_AVAILABLE, _MATPLOTLIB_AVAILABLE
+from flash.core.utilities.imports import _FIFTYONE_AVAILABLE, _KORNIA_AVAILABLE, _MATPLOTLIB_AVAILABLE
+
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.labels import Segmentation
 
 if _MATPLOTLIB_AVAILABLE:
     import matplotlib.pyplot as plt
@@ -80,3 +83,13 @@ class SegmentationLabels(Serializer):
             plt.imshow(labels_vis)
             plt.show()
         return labels
+
+
+class FiftyOneSegmentationLabels(SegmentationLabels):
+
+     def serialize(self, sample: Dict[str, torch.Tensor]) -> Segmentation:
+        preds = sample[DefaultDataKeys.PREDS]
+        assert len(preds.shape) == 3, preds.shape
+        labels = torch.argmax(preds, dim=-3).numpy()  # HxW
+
+        return Segmentation(mask=labels)

--- a/flash/video/classification/data.py
+++ b/flash/video/classification/data.py
@@ -137,7 +137,9 @@ class VideoClassificationFiftyOneDataSource(FiftyOneDataSource, VideoClassificat
         decoder: str = "pyav",
         label_field: str = "ground_truth",
     ):
-        super().__init__(
+        if not _FIFTYONE_AVAILABLE:
+            raise ModuleNotFoundError("Please, run `pip install fiftyone`.")
+        VideoClassificationPathsDataSource.__init__(
             clip_sampler=clip_sampler,
             video_sampler=video_sampler,
             decode_audio=decode_audio,

--- a/flash/video/classification/data.py
+++ b/flash/video/classification/data.py
@@ -20,10 +20,25 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from torch.utils.data import RandomSampler, Sampler
 
 from flash.core.data.data_module import DataModule
-from flash.core.data.data_source import DefaultDataKeys, DefaultDataSources, LabelsState, PathsDataSource
+from flash.core.data.data_source import (
+    DefaultDataKeys, 
+    DefaultDataSources, 
+    FiftyOneDataSource,
+    LabelsState, 
+    PathsDataSource,
+)
 from flash.core.data.process import Preprocess
 from flash.core.data.transforms import merge_transforms
-from flash.core.utilities.imports import _KORNIA_AVAILABLE, _PYTORCHVIDEO_AVAILABLE
+from flash.core.utilities.imports import (
+    _KORNIA_AVAILABLE,
+    _FIFTYONE_AVAILABLE,
+    _PYTORCHVIDEO_AVAILABLE,
+)
+
+if _FIFTYONE_AVAILABLE:
+    from fiftyone.core.collections import SampleCollection
+else:
+    SampleCollection = None
 
 if _KORNIA_AVAILABLE:
     import kornia.augmentation as K

--- a/flash/video/classification/data.py
+++ b/flash/video/classification/data.py
@@ -151,8 +151,7 @@ class VideoClassificationFiftyOneDataSource(FiftyOneDataSource, VideoClassificat
         label_to_class_mapping = dict(enumerate(data.default_classes))
         class_to_label_mapping = {c:l for l,c in label_to_class_mapping.items()}
 
-        filepaths = data.values("filepath")
-        labels = data.values(self.label_field + ".label")
+        filepaths, labels = data.values(["filepath", self.label_field+".label"])
 
         targets = [class_to_label_mapping[l] for l in labels]
         labeled_video_paths = list(zip(filepaths, targets))


### PR DESCRIPTION
## What does this PR do?

Integrates lightning flash with the analysis and visualization tool, FiftyOne. Primarily adds:
* `VideoClassificationData.from_fiftyone` loading data directly from FiftyOne datasets
* `FiftyOneLabels()` serializer returning predictions in the FiftyOne Classification(s) format

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/lightning-flash/tree/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? [not needed for typos/docs]
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/lightning-flash/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
